### PR TITLE
Fix user image path in example site

### DIFF
--- a/examples/basics/siteConfig.js
+++ b/examples/basics/siteConfig.js
@@ -12,9 +12,9 @@
 const users = [
   {
     caption: 'User1',
-    image: '/img/docusaurus.svg',
     // You will need to prepend the image path with your baseUrl
     // if it is not '/', like: '/test-site/img/docusaurus.svg'.
+    image: '/img/docusaurus.svg',
     infoLink: 'https://www.facebook.com',
     pinned: true,
   },

--- a/examples/basics/siteConfig.js
+++ b/examples/basics/siteConfig.js
@@ -13,7 +13,7 @@ const users = [
   {
     caption: 'User1',
     image: '/img/docusaurus.svg',
-    // You will need to add your prepend the image path with your baseUrl
+    // You will need to prepend the image path with your baseUrl
     // if it is not '/', like: '/test-site/img/docusaurus.svg'.
     infoLink: 'https://www.facebook.com',
     pinned: true,

--- a/examples/basics/siteConfig.js
+++ b/examples/basics/siteConfig.js
@@ -12,7 +12,9 @@
 const users = [
   {
     caption: 'User1',
-    image: '/test-site/img/docusaurus.svg',
+    image: '/img/docusaurus.svg',
+    // You will need to add your prepend the image path with your baseUrl
+    // if it is not '/', like: '/test-site/img/docusaurus.svg'.
     infoLink: 'https://www.facebook.com',
     pinned: true,
   },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Docusaurus here: https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The user image in the example site is broken due to a wrongly configured path.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Before

<img width="521" alt="screen shot 2018-04-24 at 11 24 57 pm" src="https://user-images.githubusercontent.com/1315101/39229796-f36c03d4-4818-11e8-9c05-ef2918c2a611.png">

After

<img width="585" alt="screen shot 2018-04-24 at 11 25 04 pm" src="https://user-images.githubusercontent.com/1315101/39229800-f80ffab2-4818-11e8-823d-9fe0c58fcbe9.png">

## Related PRs

NA